### PR TITLE
Treat Linux running in EC2 the same as Amazon Linux

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email "hikeit@gmail.com"
 license          "Apache License"
 description      "Configures authconfig"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "2.0.1"
+version          "2.0.2"


### PR DESCRIPTION
Checking for `node['platform'] = 'amazon'` is not enough to determine if the node is running in amazon.

We should also check `node['cloud']['provider'] = 'ec2'` to catch amazon nodes that aren't running amazon linux.