### PR TITLE
Chef 13 Compatibility

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email "hikeit@gmail.com"
 license          "Apache License"
 description      "Configures authconfig"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "2.0.2"
+version          "2.0.3"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,7 +25,7 @@ sssd_action = nil
 nslcd_enable = false
 case node['platform']
 when 'redhat', 'centos', 'scientific'
-  if node&.cloud&.provider.downcase == 'ec2'
+  if node.dig('cloud', 'provider')&.downcase == 'ec2'
     # this is also amazon, so do the same thing as when node['platform'] = amazon
     node.default['authconfig']['ldap']['packages'] = ['nss-pam-ldapd','pam_ldap']
     authconfig_action = 'install'


### PR DESCRIPTION
- Bump version to 2.0.3
- Fix issue with Chef 13 where node attributes are not allowed to be accessed with `.`